### PR TITLE
generalize 1-Deploy_Linode_Ceph_Cluster to do non-linode clusters

### DIFF
--- a/scripts/jobs/1-Deploy_Ceph_Cluster.sh
+++ b/scripts/jobs/1-Deploy_Ceph_Cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +x
+#!/usr/bin/bash +x
 
 # this script implements the Jenkins job by the same name,
 # just call it in the "Execute shell" field 
@@ -10,125 +10,176 @@
 # Jenkins will stop the pipeline immediately,
 # this makes troubleshooting a pipeline much easier for the user
 
+echo "test test test"
+NOTOK=1   # process exit status indicating failure
+
+
 script_dir=$HOME/automated_ceph_test
-inventory_file=$script_dir/ansible_inventory
 
-echo "$ceph_inventory" > $inventory_file
-if [ -d /usr/share/ceph-ansible ]; then
-	echo "purging cluster and removing previous version of ceph-ansible"
-	cd /usr/share/ceph-ansible
-	cp infrastructure-playbooks/purge-cluster.yml .
-	ansible-playbook purge-cluster.yml -i $inventory_file -e ireallymeanit=yes
-fi
-
-sudo yum remove ceph-ansible -y
-
-#clearout ceph-ansible staging area 
-
-if [ ! -d $script_dir/staging_area/rhcs_latest/ ]; then
-	mkdir -p $script_dir/staging_area/rhcs_latest
-    mkdir -p $script_dir/staging_area/rhcs_old
-    chmod -R 777 $script_dir/staging_area/
-
-
+hostname | grep linode.com
+if [ $? = 0 ] ; then
+    linode_cluster=1
+    inventory_file=$HOME/ceph-linode/ansible_inventory
 else
-	mv $script_dir/staging_area/rhcs_latest/* $script_dir/staging_area/rhcs_old/
-	pwd
+    inventory_file=$script_dir/ansible_inventory
+    echo "$ceph_inventory" > $inventory_file
 fi
-	cd $script_dir/staging_area/rhcs_latest/
-	 
-sudo rm -rf /ceph-ansible-keys
-sudo mkdir -m0777 /ceph-ansible-keys
+# careful, inventory file may not exist yet
+export ANSIBLE_INVENTORY=$inventory_file
 
-#pull iso
-if [[ $ceph_iso_file =~ "RHCEPH-*-x86_64-dvd.iso" ]]; then
-	echo "**************$ceph_iso_file"
-	sudo wget -r -nd --no-parent -A "$ceph_iso_file" $ceph_iso_path &> /dev/null
-    new_ceph_iso_file="$(ls)"
-else
-	sudo wget $ceph_iso_path/$ceph_iso_file &> /dev/null
-fi
- chmod 777 $ceph_iso_file
+called_from_deploy=1 bash -x $script_dir/scripts/jobs/5-Teardown_Ceph_Cluster.sh
 
+# clean house, so we don't have previous version of Ceph interfering
+#yum remove ceph-base ceph-ansible ansible librados2 -y
+#rm -rf /usr/share/ceph-ansible
+#rm -f /etc/ceph/ceph.conf /etc/ceph/ceph.client.admin.keyring
+yum-config-manager --disable epel
+
+cd $script_dir/staging_area/rhcs_latest/
+new_ceph_iso_file="$(ls)"
+
+rm -rf /ceph-ansible-keys
+mkdir -m0777 /ceph-ansible-keys
 
 #mount ISO and create rhcs yum repo file 
-sudo cp $script_dir/staging_area/repo_files/rhcs.repo /etc/yum.repos.d/
-sudo mkdir -p /mnt/rhcs_latest/
-sudo umount /mnt/rhcs_latest/
-sudo mount $script_dir/staging_area/rhcs_latest/RHCEPH* /mnt/rhcs_latest/
-sudo yum clean all
 
+cp $script_dir/staging_area/repo_files/rhcs.repo /etc/yum.repos.d/
+mkdir -p /mnt/rhcs_latest/
+umount /mnt/rhcs_latest/
+mount $script_dir/staging_area/rhcs_latest/RHCEPH* /mnt/rhcs_latest/
+yum clean all
 
-#install ceph-ansible
-sudo yum install ceph-ansible -y
+# install precise ansible version if necessary
 
-#added in order to allow installation of bluestore on lVMs
-patch /usr/share/ceph-ansible/roles/ceph-osd/tasks/check_mandatory_vars.yml ~/automated_ceph_test/scripts/patches/check_mandatory_vars.patch
-patch /usr/share/ceph-ansible/roles/ceph-osd/tasks/scenarios/lvm.yml ~/automated_ceph_test/scripts/lvm.patch
+if [ -n "$ansible_version" ] ; then
+    yum install -y ansible-$ansible_version
+fi
 
+#install ceph-ansible and ceph client packages
+#there must not be any dependencies on ceph-selinux 
+#for this to work reliably
+# break this up into separate installs so yum doesn't choke
 
-sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /usr/share/ceph-ansible/roles/ceph-common/templates/redhat_storage_repo.j2
+yum install ceph-fuse -y
+yum install ceph-common -y
+yum install ceph-ansible -y
+yum install ceph-fuse ceph-common ceph-ansible -y || exit $NOTOK
+
+# disable key checking in Ceph RPMs to avoid need for 
+# "redhatbuild" GPG RPM key in beta releases
+# described at https://wiki.test.redhat.com/CEPH
+
+sed -i 's/gpgcheck=1/gpgcheck=0/g' /usr/share/ceph-ansible/roles/ceph-common/templates/redhat_storage_repo.j2
+
+# provide inputs to ceph-ansible
 
 mkdir -p $script_dir/staging_area/tmp
-#setup all.yml
 echo "$ceph_ansible_all_config" > $script_dir/staging_area/tmp/all.yml
-if [[ $ceph_iso_file =~ "RHCEPH-*-x86_64-dvd.iso" ]]; then
-	sed -i "s/RHCEPH.*$/$new_ceph_iso_file/g" $script_dir/staging_area/tmp/all.yml
-fi
-sudo cp $script_dir/staging_area/tmp/all.yml /usr/share/ceph-ansible/group_vars/all.yml
-
-
-#setup osd.yml
+sed -i "s/<ceph_iso_file>/$new_ceph_iso_file/g" $script_dir/staging_area/tmp/all.yml
+cp $script_dir/staging_area/tmp/all.yml /usr/share/ceph-ansible/group_vars/all.yml
 echo "$ceph_ansible_osds_config" > $script_dir/staging_area/tmp/osds.yml
-sudo cp $script_dir/staging_area/tmp/osds.yml /usr/share/ceph-ansible/group_vars/osds.yml
+cp $script_dir/staging_area/tmp/osds.yml /usr/share/ceph-ansible/group_vars/osds.yml
+ln -svf /usr/share/ceph-ansible/site.yml.sample /usr/share/ceph-ansible/site.yml
 
+if [ -n "$linode_cluster" ] ; then
+    # set up python environment for linode API
 
-#copy site.yml
-sudo cp /usr/share/ceph-ansible/site.yml.sample /usr/share/ceph-ansible/site.yml
-
-$script_dir/scripts/utils/register_host.sh $inventory_file
-
-echo "Start Ceph installation"
-cd /usr/share/ceph-ansible
-ANSIBLE_STRATEGY=debug; ansible-playbook -v site.yml -i $inventory_file
-exit_status=$?
-
-if [ "$exit_status" -gt "0" ]; then
-	echo "ceph-ansible install failed"
-	exit $exit_status
+    cd $HOME/ceph-linode
+    echo "$Linode_Cluster_Configuration" > cluster.json
+    virtualenv-2 linode-env && source linode-env/bin/activate && pip install linode-python
+    export LINODE_API_KEY=$linode_api_key
 fi
-	
-sleep 30
-yum install ceph-common -y
-#save off the first mon in the inventory list, used to fetch ceph.conf file for agent host. 
-for i in `ansible --list-host -i $inventory_file mons |grep -v hosts | grep -v ":"`
-    do
-    	monname=$i
-    	break
-done
 
-ansible -m fetch -a "src=/etc/ceph/ceph.conf dest=/etc/ceph/ceph.conf.d" $monname -i $inventory_file
-cp /etc/ceph/ceph.conf.d/$monname/etc/ceph/ceph.conf /etc/ceph/ceph.conf
+# if we have a version adjustment repo, use it
+# use that before you try ceph-ansible
+# this works around the lack of correct ansible version and/or
+# and lack of latest versions of selinux-policy RPMs in centos/RHEL GA
+# when a new RHCS version is released.
+# the extra repo we insert is given by version_adjust_repo URL parameter
+# also passed to preceding 1A job
 
-ceph_client_key=/ceph-ansible-keys/`ls /ceph-ansible-keys/ | grep -v conf`/etc/ceph/ceph.client.admin.keyring
-cp $ceph_client_key /etc/ceph/ceph.client.admin.keyring
-ansible -m copy -a 'src=/etc/ceph/ceph.client.admin.keyring dest=/etc/ceph/' -i $inventory_file clients
+if [ -n "$version_adjust_repo" ] ; then 
 
-#Health check
-$script_dir/scripts/utils/check_cluster_status.py
-exit_status=$?
+    if [ -n "$linode_cluster" ] ; then
+        # this is a hack to let launch.sh create linodes and ansible inventory
+        # without actually running ceph-ansible
 
-exit $exit_status
+        mkdir -p /tmp/ceph-ansible/roles
+        touch /tmp/ceph-ansible/site.yml.sample
+        # just create VMs
+        /bin/bash +x ./launch.sh --ceph-ansible /tmp/ceph-ansible
+        # ignore the error status, but make sure you have inventory
+        if [ ! -f $ANSIBLE_INVENTORY ] ; then
+            echo "ERROR: no ansible inventory file available"
+            exit $NOTOK
+        fi
+    fi
+    version_adjust_name=`basename $version_adjust_repo`
+    ln -svf ~/$version_adjust_name/version_adjust.repo /etc/yum.repos.d/
+    yum clean all
+    yum install -y libselinux-python || yum upgrade -y libselinux-python
 
+    # to support ansible synchronize module
+    yum install -y rsync
+    ansible -m yum -a 'name=rsync' all
 
-#echo "Health check"
-#$script_dir/scripts/utils/check_cluster_status.sh $inventory_file
-#exit_status=$?
-#
-#if [ "$exit_status" -eq "0" ]; then
-#	#copy client key to all clients
-#	ceph_client_key=/ceph-ansible-keys/`ls /ceph-ansible-keys/ | grep -v conf`/etc/ceph/ceph.client.admin.keyring
-#	ansible -m copy -a "src=$ceph_client_key dest=/etc/ceph/ceph.client.admin.keyring" clients -i $inventory_file 
-#else
-#	exit 1
-#fi
+    # use ansible synchronize module to copy repo tree to all hosts
+    # create softlink to it in /etc/yum.repos.d
+
+    ansible -m synchronize -a "delete=yes src=~/$version_adjust_name dest=./" all
+    ansible -m shell -a \
+      "ln -svf ~/$version_adjust_name/version_adjust.repo /etc/yum.repos.d/" all
+
+    # for some reason new RHCS selinux-ceph package
+    # always has dependencies that the RHEL GA or centos 
+    # version can't satisfy.
+
+    ansible -m shell -a \
+      'yum clean all ; yum install -y libselinux-python || yum upgrade -y libselinux-python' all \
+      || exit $NOTOK
+elif [ -f $ANSIBLE_INVENTORY ] ; then
+    # remove any prior version adjustment repo
+    (ansible -m file -a "path=/etc/yum.repos.d/version_adjust.repo state=absent" all && \
+     ansible -m shell -a "yum clean all" all) || exit $NOTOK
+fi
+
+# should not have to disable firewall in Ceph after RHCS 3.1
+
+if [ "$disable_firewall" = 1 ] ; then
+    ansible -m shell -a \
+      '(systemctl stop firewalld && systemctl disable firewalld) || (systemctl stop iptables && systemctl disable iptables)' all  \
+    || exit $NOTOK
+fi
+
+# now launch ceph-ansible for real
+
+if [ -n "$linode_cluster" ] ; then
+    # run launch.sh again, this time with correct ceph-ansible path
+    # linode-launch.py will notice that the VMs have already been
+    # created and will not create any more.
+    # it will rerun pre-config.yml but this doesn't take very long
+
+    /bin/bash +x ./launch.sh --ceph-ansible /usr/share/ceph-ansible || exit $NOTOK
+else
+    # not linode
+    (cd /usr/share/ceph-ansible ; ansible-playbook -v site.yml.sample || exit $NOTOK)
+fi
+
+# find out about first monitor
+
+export first_mon=`ansible --list-host mons |grep -v hosts | grep -v ":" | head -1`
+export first_mon_ip=`ansible -m shell -a 'echo {{ hostvars[groups["mons"][0]]["ansible_ssh_host"] }}' localhost | grep -v localhost`
+
+ansible -m script -a "$script_dir/scripts/utils/check_cluster_status.py" $first_mon \
+ || exit $NOTOK
+
+# make everyone in the cluster able to run ceph -s
+# make agent able to access Ceph cluster as client
+
+(scp $first_mon_ip:/etc/ceph/ceph.conf /etc/ceph/ && \
+ scp $first_mon_ip:/etc/ceph/ceph.client.admin.keyring /etc/ceph/ && \
+ ansible -m copy -a 'src=/etc/ceph/ceph.client.admin.keyring dest=/etc/ceph/' clients) \
+ || exit $NOTOK
+
+ceph -s
+

--- a/scripts/jobs/1-Deploy_Ceph_Cluster.sh
+++ b/scripts/jobs/1-Deploy_Ceph_Cluster.sh
@@ -27,7 +27,8 @@ fi
 # careful, inventory file may not exist yet
 export ANSIBLE_INVENTORY=$inventory_file
 
-called_from_deploy=1 bash -x $script_dir/scripts/jobs/5-Teardown_Ceph_Cluster.sh
+# it is expected that the user (or pipeline) has done this first
+#  called_from_deploy=1 bash -x $script_dir/scripts/jobs/5-Teardown_Ceph_Cluster.sh
 
 # clean house, so we don't have previous version of Ceph interfering
 #yum remove ceph-base ceph-ansible ansible librados2 -y


### PR DESCRIPTION
DO NOT MERGE QUITE YET, need to test against BAGL (should be tomorrow)
diff this against 1-Deploy_Linode_Ceph_Cluster.sh to understand it
see if it's linode by checking hostname
call 5-Teardown_Ceph_Cluster to clean up agent before running
pass called_from_deploy environment variable to it
if not linode, run ceph-ansible playbook directly