### PR TITLE
make cluster status health check work in alias

### DIFF
--- a/scripts/jobs/1-Deploy_Ceph_Cluster.sh
+++ b/scripts/jobs/1-Deploy_Ceph_Cluster.sh
@@ -168,9 +168,8 @@ fi
 
 # find out about first monitor
 
-export first_mon=`ansible --list-host mons |grep -v hosts | grep -v ":" | head -1`
-export first_mon_ip=`ansible -m shell -a 'echo {{ hostvars[groups["mons"][0]]["ansible_ssh_host"] }}' localhost | grep -v localhost`
-
+export first_mon=`ansible --list-host mons |grep -v hosts | grep -v ":" | head -1 | sed 's/ //g'`
+export first_mon_ip=`ansible -m shell -a 'echo {{ hostvars[groups["mons"][0]]["inventory_hostname"] }}' localhost | grep -v localhost | sed 's/ //g'`
 ansible -m script -a "$script_dir/scripts/utils/check_cluster_status.py" $first_mon \
  || exit $NOTOK
 


### PR DESCRIPTION
without breaking it on any other cluster
remove blanks from first_mon and first_mon_ip vars
use inventory_hostname instead ansible_ssh_host,
which may not be defined in some configs